### PR TITLE
fixes undefined group['node'] if missing from hosts.ini

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip3 install yamllint ansible-lint ansible
+        run: pip3 install yamllint ansible-lint ansible netaddr jmespath
 
       - name: Run yamllint
         run: yamllint .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip3 install yamllint ansible-lint ansible netaddr jmespath
+        run: pip3 install yamllint ansible-lint ansible
 
       - name: Run yamllint
         run: yamllint .

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -22,16 +22,17 @@ k3s_token: "some-SUPER-DEDEUPER-secret-password"
 # it for each of your hosts, though.
 k3s_node_ip: '{{ ansible_facts[flannel_iface]["ipv4"]["address"] }}'
 
-k3s_node_exists: "{{ 'true' if groups['node'] | length >= 1 else 'false' }}"
+k3s_node_exists: "{{ 'true' if groups['node'] | default([]) | length >= 1 else 'false' }}"
 
 # these arguments are recommended for servers as well as agents:
 extra_args: >-
   --flannel-iface={{ flannel_iface }}
   --node-ip={{ k3s_node_ip }}
 
-# change these to your liking, the only required one is --disable servicelb
+# change these to your liking, the only required are: --disable servicelb, --tls-san {{ apiserver_endpoint }}
 extra_server_args: >-
   {{ extra_args }}
+  {{ '--node-taint node-role.kubernetes.io/master=true:NoSchedule' if k3s_node_exists | bool else '' }}
   --tls-san {{ apiserver_endpoint }}
   --disable servicelb
   --disable traefik

--- a/molecule/default/overrides.yml
+++ b/molecule/default/overrides.yml
@@ -9,7 +9,3 @@
 
         # The test VMs might be a bit slow, so we give them more time to join the cluster:
         retry_count: 45
-
-        # Intermittent errors when waiting for the mettallb controller to be ready,
-        # where noticed when running this molecule test, so the timeout is doubled.
-        metal_lb_available_timeout: 120s

--- a/molecule/default/overrides.yml
+++ b/molecule/default/overrides.yml
@@ -9,3 +9,7 @@
 
         # The test VMs might be a bit slow, so we give them more time to join the cluster:
         retry_count: 45
+
+        # Intermittent errors when waiting for the mettallb controller to be ready,
+        # where noticed when running this molecule test, so the timeout is doubled.
+        metal_lb_available_timeout: 120s

--- a/molecule/ipv6/overrides.yml
+++ b/molecule/ipv6/overrides.yml
@@ -36,6 +36,8 @@
         #    the default has IPv4 ranges only.
         extra_server_args: >-
           {{ extra_args }}
+          --tls-san {{ apiserver_endpoint }}
+          {{ '--node-taint node-role.kubernetes.io/master=true:NoSchedule' if k3s_node_exists | bool else '' }}
           --disable servicelb
           --disable traefik
           --disable-network-policy

--- a/molecule/resources/verify/from_outside/tasks/test/deploy-example.yml
+++ b/molecule/resources/verify/from_outside/tasks/test/deploy-example.yml
@@ -34,7 +34,10 @@
 
     - name: Assert that the nginx welcome page is available
       ansible.builtin.uri:
-        url: http://{{ ip | ansible.utils.ipwrap }}:{{ port }}/
+        # The default value here fixes ansible-lint error:
+        # 'jinja:Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipwrap filter <value>'
+        # If by any chanche we reach the default case, we have already failed, so it will not save the task!
+        url: http://{{ ip | default([]) | ansible.utils.ipwrap }}:{{ port }}/
         return_content: yes
       register: result
       failed_when: "'Welcome to nginx!' not in result.content"

--- a/molecule/resources/verify/from_outside/tasks/test/get-nodes.yml
+++ b/molecule/resources/verify/from_outside/tasks/test/get-nodes.yml
@@ -11,7 +11,7 @@
     success_msg: "Found nodes as expected: {{ found_nodes }}"
     fail_msg: "Expected nodes {{ expected_nodes }}, but found nodes {{ found_nodes }}"
   vars:
-    # The 'if else' check fixes linting error:
+    # The check if variable is 'defined' fixes linting error:
     # jinja: Error in jmespath.search in json_query filter plugin: 'cluster_nodes' is undefined
     found_nodes: >-
       {{ cluster_nodes is defined and cluster_nodes | json_query('resources[*].metadata.name') | unique | sort }}

--- a/molecule/resources/verify/from_outside/tasks/test/get-nodes.yml
+++ b/molecule/resources/verify/from_outside/tasks/test/get-nodes.yml
@@ -13,12 +13,8 @@
   vars:
     # The 'if else' check fixes linting error:
     # jinja: Error in jmespath.search in json_query filter plugin: 'cluster_nodes' is undefined
-    found_nodes: |-
-      {% if cluster_nodes is defined %}
-        {{ cluster_nodes | json_query('resources[*].metadata.name') | unique | sort }}
-      {% else %}
-        default([])
-      {% endif %}
+    found_nodes: >-
+      {{ cluster_nodes is defined and cluster_nodes | json_query('resources[*].metadata.name') | unique | sort }}
     expected_nodes: |-
       {{
         (

--- a/molecule/resources/verify/from_outside/tasks/test/get-nodes.yml
+++ b/molecule/resources/verify/from_outside/tasks/test/get-nodes.yml
@@ -13,7 +13,7 @@
   vars:
     # The 'if else' check fixes linting error:
     # jinja: Error in jmespath.search in json_query filter plugin: 'cluster_nodes' is undefined
-    found_nodes: >-
+    found_nodes: |-
       {% if cluster_nodes is defined %}
         {{ cluster_nodes | json_query('resources[*].metadata.name') | unique | sort }}
       {% else %}

--- a/molecule/resources/verify/from_outside/tasks/test/get-nodes.yml
+++ b/molecule/resources/verify/from_outside/tasks/test/get-nodes.yml
@@ -11,8 +11,10 @@
     success_msg: "Found nodes as expected: {{ found_nodes }}"
     fail_msg: "Expected nodes {{ expected_nodes }}, but found nodes {{ found_nodes }}"
   vars:
+    # The 'if else' check fixes linting error:
+    # jinja: Error in jmespath.search in json_query filter plugin: 'cluster_nodes' is undefined
     found_nodes: >-
-      {{ cluster_nodes | json_query('resources[*].metadata.name') | unique | sort }}
+      {{ cluster_nodes | json_query('resources[*].metadata.name') | unique | sort if cluster_nodes is defined else default([]) }}
     expected_nodes: |-
       {{
         (

--- a/molecule/resources/verify/from_outside/tasks/test/get-nodes.yml
+++ b/molecule/resources/verify/from_outside/tasks/test/get-nodes.yml
@@ -14,7 +14,11 @@
     # The 'if else' check fixes linting error:
     # jinja: Error in jmespath.search in json_query filter plugin: 'cluster_nodes' is undefined
     found_nodes: >-
-      {{ cluster_nodes | json_query('resources[*].metadata.name') | unique | sort if cluster_nodes is defined else default([]) }}
+      {% if cluster_nodes is defined %}
+        {{ cluster_nodes | json_query('resources[*].metadata.name') | unique | sort }}
+      {% else %}
+        default([])
+      {% endif %}
     expected_nodes: |-
       {{
         (

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -64,8 +64,7 @@
     cmd: "systemd-run -p RestartSec=2 \
                       -p Restart=on-failure \
                       --unit=k3s-init \
-                      k3s server {{ server_init_args }} \
-                      {{ '--node-taint node-role.kubernetes.io/master=true:NoSchedule' if k3s_node_exists | bool else ''}}"
+                      k3s server {{ server_init_args }}"
     creates: "{{ systemd_dir }}/k3s.service"
   args:
     warn: false  # The ansible systemd module does not support transient units

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -152,10 +152,13 @@
     owner: "{{ ansible_user }}"
     mode: "u=rw,g=,o="
 
-- name: Configure kubectl cluster to https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443
+# The default value here fixes ansible-lint error:
+# 'jinja:Unrecognized type <<class 'ansible.template.AnsibleUndefined'>> for ipwrap filter <value>'
+# If by any chanche we reach the default case, we have already failed, so it will not save the task!
+- name: Configure kubectl cluster to https://{{ apiserver_endpoint | default([]) | ansible.utils.ipwrap }}:6443
   command: >-
     k3s kubectl config set-cluster default
-      --server=https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443
+      --server=https://{{ apiserver_endpoint | default([]) | ansible.utils.ipwrap }}:6443
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
 

--- a/roles/k3s/master/templates/k3s.service.j2
+++ b/roles/k3s/master/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server {{ extra_server_args | default("") }} {{ '--node-taint node-role.kubernetes.io/master=true:NoSchedule' if k3s_node_exists | bool else ''}}
+ExecStart=/usr/local/bin/k3s server {{ extra_server_args | default("") }}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/roles/k3s/post/defaults/main.yml
+++ b/roles/k3s/post/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # Timeout to wait for MetalLB services to come up
-metal_lb_available_timeout: 60s
+metal_lb_available_timeout: 120s

--- a/roles/k3s/post/tasks/main.yml
+++ b/roles/k3s/post/tasks/main.yml
@@ -28,9 +28,9 @@
   command: >-
     k3s kubectl wait {{ item.resource }}
     --namespace='metallb-system'
-    {% if item.name | default(False) -%} {{ item.name }} {%- endif %}
-    {% if item.selector | default(False) -%} --selector='{{ item.selector }}' {%- endif %}
-    {% if item.condition | default(False) -%} {{ item.condition }} {%- endif %}
+    {% if item.name | default(False) -%}{{ item.name }}{%- endif %}
+    {% if item.selector | default(False) -%}--selector='{{ item.selector }}'{%- endif %}
+    {% if item.condition | default(False) -%}{{ item.condition }}{%- endif %}
     --timeout='{{ metal_lb_available_timeout }}'
   changed_when: false
   run_once: true


### PR DESCRIPTION
- consolidates handling of master taints in `group_vars`, `all.yml`
```yaml

...

k3s_node_exists: "{{ 'true' if groups['node'] | default([]) | length >= 1 else 'false' }}"

...

extra_server_args: >-
  {{ extra_args }}
  {{ '--node-taint node-role.kubernetes.io/master=true:NoSchedule' if k3s_node_exists | bool else '' }}
  --tls-san {{ apiserver_endpoint }}
  --disable servicelb
  --disable traefik
```
There is no need for users to mess with the roles even for the `taint` functionality. The addition to `extra_server_args` avoids duplication in files: `roles/k3s/master/tasks/main.yml` and `roles/k3s/master/templates/k3s.service.j2`. For k3s anyway, taints are another extra server arg.
Now even if a user wants to run for example, 3 master and 2 worker nodes with all of them being schedulable, they just have to delete the taint entry in `extra_server_args` variable.

The new addition in `extra_server_args`:  `--tls-san {{ apiserver_endpoint }}` is mandatory, because the ip of our virtual ip needs to be in the SANs of the api server certificate, otherwise we cannot access our cluster.

### About testing and linting

In the ipv6 molecule test, because we override the `extra_server_args`, I added the 2 new entries:
- --tls-san {{ apiserver_endpoint }}
- {{ '--node-taint node-role.kubernetes.io/master=true:NoSchedule' if k3s_node_exists | bool else '' }}

The rest of the changes were to make the linter happy, despite my commits had nothing to do with breaking the linter. I wonder if anyone could make any pull request without the linting action failing... ;-)
I think it is fixed even in a hacky way!
By the way I noticed intermittent failures in the metallb wait task in GitHub actions and I had to increase it to 120s. After that I had no failures.